### PR TITLE
Bump `near-api-js` dependency to `^2.1.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 }}>
 ```
 
+- Bump `near-api-js` dependency to `^2.1.2`
+
 ## 1.3.1
 
 - Fix the minimum storage deposit for a new account to be attached. This happened because the permission is granted by default, and the logic relied on it first.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.21",
     "mdast-util-find-and-replace": "^2.0.0",
     "nanoid": "^4.0.1",
-    "near-api-js": "^2.1.0",
+    "near-api-js": "^2.1.2",
     "prettier": "^2.7.1",
     "react-bootstrap": "^2.5.0",
     "react-bootstrap-typeahead": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,17 +1420,17 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@near-js/accounts@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@near-js/accounts/-/accounts-0.1.0.tgz#3fd44ec290eed196babe31adeac5aea40ccf01dd"
-  integrity sha512-2VCo8qJRkzzw2p7Na/ApMqn18JXBdQQU9jQMWgcYA/U8yw39EsmXoMTUFsfI9vKoQOmeRgxR5efwQn48rtuJNw==
+"@near-js/accounts@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@near-js/accounts/-/accounts-0.1.2.tgz#680efaa4b4addcfe9d79771406d2d8e0dea41443"
+  integrity sha512-cZ1+zn9elRm0xHlSR+NbNnRfbk/BiGjFZEdu8y5qp4yfCR+0Y/PsYcJSrXg5pn/eCZsDdmrATVL041Si+V+M7Q==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/providers" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/providers" "0.0.5"
+    "@near-js/signers" "0.0.4"
+    "@near-js/transactions" "0.1.1"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     ajv "^8.11.2"
     ajv-formats "^2.1.1"
     bn.js "5.2.1"
@@ -1438,105 +1438,105 @@
     depd "^2.0.0"
     near-abi "0.1.1"
 
-"@near-js/crypto@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-0.0.3.tgz#4a33e526ab5fa75b703427067985694a279ff8bd"
-  integrity sha512-3WC2A1a1cH8Cqrx+0iDjp1ASEEhxN/KHEMENYb0KZH6Hp5bXIY7Akt4quC7JlgJS5ESvEiLa40tS5h0zAhBWGw==
+"@near-js/crypto@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/crypto/-/crypto-0.0.4.tgz#7bb991da25f06096de51466c6331cb185314fad8"
+  integrity sha512-2mSIVv6mZway1rQvmkktrXAFoUvy7POjrHNH3LekKZCMCs7qMM/23Hz2+APgxZPqoV2kjarSNOEYJjxO7zQ/rQ==
   dependencies:
-    "@near-js/types" "0.0.3"
+    "@near-js/types" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
     tweetnacl "^1.0.1"
 
-"@near-js/keystores-browser@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.3.tgz#110b847cd9c358076c2401e9462cc1140e12a908"
-  integrity sha512-Ve/JQ1SBxdNk3B49lElJ8Y54AoBY+yOStLvdnUIpe2FBOczzwDCkcnPcMDV0NMwVlHpEnOWICWHbRbAkI5Vs+A==
+"@near-js/keystores-browser@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-browser/-/keystores-browser-0.0.4.tgz#9c1130e2c0becf6bb9cfaaa7594ad38ed25585bd"
+  integrity sha512-bzwClm3jNlWJrb8wqMunP3rrcG1hS3rD58KKhDvHXy8Dtg9VVUgrfr3Csu9oTnjG+rAPZGOynunaoOQVqju/Aw==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
 
-"@near-js/keystores-node@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/keystores-node/-/keystores-node-0.0.3.tgz#074e0aadb55b2ceda43f4389b253193d7a7d7057"
-  integrity sha512-8Yry0jARK2R2+V4KjEganrnpXhosArwgpyrbvtvptwLLNNFvo/AY1ekGV1EpQ3BVst1qvf5R5TXnIti9OBmEHw==
+"@near-js/keystores-node@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores-node/-/keystores-node-0.0.4.tgz#00187deef2d43afeb20c01a0e63ec50af77cfc85"
+  integrity sha512-vOdVhAuQ8BVefEluj+TSNzjXHA/1xjEgK7pwBUA1kgpcY8/hZ0Jj4PcvPD17wQNSyP+NJF5H9ed3pP2h2VH+1A==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
 
-"@near-js/keystores@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.3.tgz#eb1e8e06936da166b5ed8dab3123eaa1bf7a8dab"
-  integrity sha512-mnwLYUt4Td8u1I4QE1FBx2d9hMt3ofiriE93FfOluJ4XiqRqVFakFYiHg6pExg5iEkej/sXugBUFeQ4QizUnew==
+"@near-js/keystores@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/keystores/-/keystores-0.0.4.tgz#da03069497bb14741a4d97f7ad4746baf9a09ea7"
+  integrity sha512-+vKafmDpQGrz5py1liot2hYSjPGXwihveeN+BL11aJlLqZnWBgYJUWCXG+uyGjGXZORuy2hzkKK6Hi+lbKOfVA==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/types" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/types" "0.0.4"
 
-"@near-js/providers@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/providers/-/providers-0.0.3.tgz#95f71f9d81139f9eb54a287f859785d75ed007f3"
-  integrity sha512-NblqLsPfKIWKwQZh+dLZs0nQ+Dx9/MrP1uagRmxZd+aEN/IgYr7Q0mdT77WHQKrsgXiMnipknRZxeoY5bImCuw==
+"@near-js/providers@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@near-js/providers/-/providers-0.0.5.tgz#3d214b299aa8fce25c7583bd652269453a56cfd2"
+  integrity sha512-uK0Vamv9NwYu9jxK2p8KpycxzWf/UKMmPzP1wCTprwr0j+Ta0Wl9SuD1DSQWyksg7Cr57hI0Y5D1bdaMK/XJjg==
   dependencies:
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/transactions" "0.1.1"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
     http-errors "^1.7.2"
   optionalDependencies:
     node-fetch "^2.6.1"
 
-"@near-js/signers@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/signers/-/signers-0.0.3.tgz#bfc8386613295fc6b51982cf65c79bdc9307aa5e"
-  integrity sha512-u1R+DDIua5PY1PDFnpVYqdMgQ7c4dyeZsfqMjE7CtgzdqupgTYCXzJjBubqMlAyAx843PoXmLt6CSSKcMm0WUA==
+"@near-js/signers@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/signers/-/signers-0.0.4.tgz#a1904ccc718d6f87b05cd2e168f33bde0cfb269a"
+  integrity sha512-xCglo3U/WIGsz/izPGFMegS5Q3PxOHYB8a1E7RtVhNm5QdqTlQldLCm/BuMg2G/u1l1ZZ0wdvkqRTG9joauf3Q==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
     js-sha256 "^0.9.0"
 
-"@near-js/transactions@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@near-js/transactions/-/transactions-0.1.0.tgz#a03f529da6bb2eaf9dd0590093f2d0763b8ae72a"
-  integrity sha512-OrrDFqhX0rtH+6MV3U3iS+zmzcPQI+L4GJi9na4Uf8FgpaVPF0mtSmVrpUrS5CC3LwWCzcYF833xGYbXOV4Kfg==
+"@near-js/transactions@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@near-js/transactions/-/transactions-0.1.1.tgz#3d4c9d8e3cf2543642d660c0c0b126f0a97d5d43"
+  integrity sha512-Fk83oLLFK7nz4thawpdv9bGyMVQ2i48iUtZEVYhuuuqevl17tSXMlhle9Me1ZbNyguJG/cWPdNybe1UMKpyGxA==
   dependencies:
-    "@near-js/crypto" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/signers" "0.0.4"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
     js-sha256 "^0.9.0"
 
-"@near-js/types@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/types/-/types-0.0.3.tgz#d504222469f4d50a6299c522fb6905ba10905bd6"
-  integrity sha512-gC3iGUT+r2JjVsE31YharT+voat79ToMUMLCGozHjp/R/UW1M2z4hdpqTUoeWUBGBJuVc810gNTneHGx0jvzwQ==
+"@near-js/types@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/types/-/types-0.0.4.tgz#d941689df41c850aeeeaeb9d498418acec515404"
+  integrity sha512-8TTMbLMnmyG06R5YKWuS/qFG1tOA3/9lX4NgBqQPsvaWmDsa+D+QwOkrEHDegped0ZHQwcjAXjKML1S1TyGYKg==
   dependencies:
     bn.js "5.2.1"
 
-"@near-js/utils@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/utils/-/utils-0.0.3.tgz#5e631f3dbdb7f0c6985bcbef08644db83b519978"
-  integrity sha512-J72n/EL0VfLRRb4xNUF4rmVrdzMkcmkwJOhBZSTWz3PAZ8LqNeU9ZConPfMvEr6lwdaD33ZuVv70DN6IIjPr1A==
+"@near-js/utils@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@near-js/utils/-/utils-0.0.4.tgz#1a387f81974ebbfa4521c92590232be97e3335dd"
+  integrity sha512-mPUEPJbTCMicGitjEGvQqOe8AS7O4KkRCxqd0xuE/X6gXF1jz1pYMZn4lNUeUz2C84YnVSGLAM0o9zcN6Y4hiA==
   dependencies:
-    "@near-js/types" "0.0.3"
+    "@near-js/types" "0.0.4"
     bn.js "5.2.1"
     depd "^2.0.0"
     mustache "^4.0.0"
 
-"@near-js/wallet-account@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@near-js/wallet-account/-/wallet-account-0.0.3.tgz#81f6a0fc6d4f4ffcdb2c895186fdd86baf9a7b44"
-  integrity sha512-FD/v0z9HzXfmEerfhRde9HUOojh9IM7nXxCJZm6UF49aA2ztlaqbGvmXSfD+yvf3WG58pC5eUFvDl1sdco8jhQ==
+"@near-js/wallet-account@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@near-js/wallet-account/-/wallet-account-0.0.5.tgz#ee50671a9e0b581dd8006e8c9274d794d36a26a0"
+  integrity sha512-iVYXERRoIgQuOHIuyxnAqG+t0V9jkHxplU+KLOUwLr5ClL9zH9v25OnXf5r4b4inPLhRg5G+tMhX6n7ScnJaQA==
   dependencies:
-    "@near-js/accounts" "0.1.0"
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
+    "@near-js/accounts" "0.1.2"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
+    "@near-js/signers" "0.0.4"
+    "@near-js/transactions" "0.1.1"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
     bn.js "5.2.1"
     borsh "^0.7.0"
 
@@ -6296,22 +6296,22 @@ near-abi@0.1.1:
   dependencies:
     "@types/json-schema" "^7.0.11"
 
-near-api-js@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-2.1.0.tgz#dbdef65bbfb735de8f891309e198c27254fbe9c5"
-  integrity sha512-JH+xwBPCo8GZlJoJuStI38nfyBIT21iGXofq/X/ewi2pvMFAgpqCantiGgbm0zujyQLPwQPmA+PMm5VKC8y+nQ==
+near-api-js@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-2.1.2.tgz#b5aa165e0f2893d7f8ee0f752bcb20f180c745d5"
+  integrity sha512-Okb+q/q/LOegub70C9umtIyyc5lEpz98cATl/EbTEE0bm5natrXrJUclgsC7cs6ithr8KwyvcTa8kAh2w5mGZg==
   dependencies:
-    "@near-js/accounts" "0.1.0"
-    "@near-js/crypto" "0.0.3"
-    "@near-js/keystores" "0.0.3"
-    "@near-js/keystores-browser" "0.0.3"
-    "@near-js/keystores-node" "0.0.3"
-    "@near-js/providers" "0.0.3"
-    "@near-js/signers" "0.0.3"
-    "@near-js/transactions" "0.1.0"
-    "@near-js/types" "0.0.3"
-    "@near-js/utils" "0.0.3"
-    "@near-js/wallet-account" "0.0.3"
+    "@near-js/accounts" "0.1.2"
+    "@near-js/crypto" "0.0.4"
+    "@near-js/keystores" "0.0.4"
+    "@near-js/keystores-browser" "0.0.4"
+    "@near-js/keystores-node" "0.0.4"
+    "@near-js/providers" "0.0.5"
+    "@near-js/signers" "0.0.4"
+    "@near-js/transactions" "0.1.1"
+    "@near-js/types" "0.0.4"
+    "@near-js/utils" "0.0.4"
+    "@near-js/wallet-account" "0.0.5"
     ajv "^8.11.2"
     ajv-formats "^2.1.1"
     bn.js "5.2.1"


### PR DESCRIPTION
Needed for near.org fast auth