### PR TITLE
Wallet Selector Compatible Transaction Object

### DIFF
--- a/src/lib/data/near.js
+++ b/src/lib/data/near.js
@@ -4,8 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import { singletonHook } from "react-singleton-hook";
 import { MaxGasPerTransaction, TGas } from "./utils";
 
-const { transactions: { functionCall: functionCallCreator }} = nearAPI;
-
 const TestNearConfig = {
   networkId: "testnet",
   nodeUrl: "https://rpc.testnet.near.org",
@@ -74,7 +72,15 @@ async function functionCall(
     console.log('sending args', args);
     return await wallet.signAndSendTransaction({
       receiverId: contractName,
-      actions: [functionCallCreator(methodName, args, gas ?? TGas.mul(30).toFixed(0), deposit ?? "0")],
+      actions: [{
+        type: "FunctionCall",
+        params: {
+            methodName: methodName,
+            args,
+            gas: gas ?? TGas.mul(30).toFixed(0),
+            deposit: deposit ?? "0"
+        }
+      }],
     });
   } catch (e) {
     // const msg = e.toString();


### PR DESCRIPTION
Currently, the VM uses the near-api-js transaction object as seen [here](https://github.com/NearSocial/VM/blob/3b9cb91ec2ea6b2c6a5182ba8cff062104bbc123/src/lib/data/near.js#L75-L77C22) even though the wallet selector’s signAndSendTransaction parameters are expected to be a different type as seen [here](https://github.com/near/wallet-selector/blob/cc9ba7440eb75152a4c33a97e9931670b33d8c90/packages/core/src/lib/wallet/wallet.types.ts#L83-L96).

I've changed the transaction object to match the selector.