### PR TITLE
feat: collect analytics if callback passed in

### DIFF
--- a/src/lib/components/Widget.js
+++ b/src/lib/components/Widget.js
@@ -55,9 +55,9 @@ export const Widget = React.forwardRef((props, forwardedRef) => {
     depth,
     config: propsConfig,
     props: propsProps,
+    analyticsCallback,
     ...forwardedProps
   } = props;
-
   const [nonce, setNonce] = useState(0);
   const [code, setCode] = useState(null);
   const [src, setSrc] = useState(null);
@@ -189,6 +189,7 @@ export const Widget = React.forwardRef((props, forwardedRef) => {
       version: uuid(),
       widgetConfigs: configs,
       ethersProviderContext,
+      analyticsCallback,
     });
     setVm(vm);
     return () => {
@@ -203,6 +204,7 @@ export const Widget = React.forwardRef((props, forwardedRef) => {
     confirmTransactions,
     configs,
     ethersProviderContext,
+    analyticsCallback,
   ]);
 
   useEffect(() => {

--- a/src/lib/vm/vm.js
+++ b/src/lib/vm/vm.js
@@ -607,6 +607,21 @@ class VmStack {
         }
       });
     } else if (element === "Widget") {
+      if (this.vm.analyticsCallback) {
+        const anlayticsContext = {
+          widgetSrc: this.vm.widgetSrc,
+          state: this.vm.state.state,
+          context: this.vm.state.context,
+          props: this.vm.state.props,
+          key: attributes.key,
+        };
+        try {
+          this.vm.analyticsCallback(anlayticsContext);
+        } catch (error) {
+          console.error("Error in analyticsCallback: ", error);
+        }
+        attributes.analyticsCallback = this.vm.analyticsCallback;
+      }
       attributes.depth = this.vm.depth + 1;
       attributes.config = [attributes.config, ...this.vm.widgetConfigs].filter(
         Boolean
@@ -1832,6 +1847,7 @@ export default class VM {
       widgetConfigs,
       ethersProviderContext,
       isModule,
+      analyticsCallback,
     } = options;
 
     this.alive = true;
@@ -1839,6 +1855,7 @@ export default class VM {
     this.rawCode = rawCode;
 
     this.near = near;
+    this.analyticsCallback = analyticsCallback;
     try {
       this.code = parseCode(rawCode);
       this.compileError = null;
@@ -2108,6 +2125,7 @@ export default class VM {
       widgetConfigs: this.widgetConfigs,
       ethersProviderContext: this.ethersProviderContext,
       isModule: true,
+      analyticsCallback: this.analyticsCallback,
     });
     this.vmInstances.set(src, vm);
     return vm;


### PR DESCRIPTION
We would like to collect analytics from the VM in order to understand which components receive the most views and are the most utilized among other stats.

Monitoring the VM will give us insights beyond just traffic usage as it can help to discover bugs in the VM to make it more performant.

You are not required to pass in an anlayticsCallback. In fact, you can leave it out and your VM should work as is.